### PR TITLE
Return an empty function when `window` is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,11 @@ var defaultOptions = {
 };
 
 export default function(opt) {
+  if (typeof window === 'undefined') {
+    // This allows authors to unit test more easily
+    return () => {}; // eslint-disable-line no-empty-function
+  }
+
   const options = {
     ...defaultOptions,
     ...opt


### PR DESCRIPTION
This change allows for simpler unit testing. Before this change, when importing and running tests against our Vuex store, we would get errors that look like this:

```
/Users/blimmer/code/my_project/node_modules/vuex/dist/vuex.common.js:345
  plugins.forEach(function (plugin) { return plugin(this$1); });
          ^
ReferenceError: window is not defined
    at /Users/blimmer/code/my_project/node_modules/vuex-webextensions/dist/index.js:1:1048
    at /Users/blimmer/code/my_project/node_modules/vuex/dist/vuex.common.js:345:46
    at Array.forEach (<anonymous>)
```

Because `window` is undefined in node environments, an exception is thrown from this line of code:

https://github.com/MitsuhaKitsune/vuex-webextensions/blob/fe0d38e5735b012a3ec928de7aead33371259b2b/src/index.js#L25

To work around this issue, this PR adds a fallback when `window` is undefined.

This change should not affect existing use-cases. If users want to test the behavior of vuex-webextensions, they can provide a real or mock `window` global.

This strategy is very similar to a browser polyfill we're using to handle differences between webextensions browsers: https://github.com/Lusito/webextension-polyfill-ts/blob/4032477890787bb18ef201c7f5030320f1777670/src/generated/index.ts#L152-L157