### PR TITLE
Bug/update detect browser

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -38,7 +38,7 @@ class Browser {
 
   detectBrowser() {
     if (typeof chrome !== 'undefined') {
-      if (typeof browser !== 'undefined') {
+      if (typeof browser !== 'undefined' && !HTMLCollection.prototype.isPrototypeOf.call(browser) && !HTMLElement.prototype.isPrototypeOf.call(browser)) {
         this.browser = browsers.firefox;
 
         return;

--- a/src/browser.js
+++ b/src/browser.js
@@ -38,7 +38,7 @@ class Browser {
 
   detectBrowser() {
     if (typeof chrome !== 'undefined') {
-      if (typeof browser !== 'undefined' && typeof InstallTrigger !== 'undefined') {
+      if (typeof InstallTrigger !== 'undefined') {
         this.browser = browsers.firefox;
 
         return;

--- a/src/browser.js
+++ b/src/browser.js
@@ -38,7 +38,7 @@ class Browser {
 
   detectBrowser() {
     if (typeof chrome !== 'undefined') {
-      if (typeof browser !== 'undefined' && !HTMLCollection.prototype.isPrototypeOf.call(browser) && !HTMLElement.prototype.isPrototypeOf.call(browser)) {
+      if (typeof browser !== 'undefined' && typeof InstallTrigger !== 'undefined') {
         this.browser = browsers.firefox;
 
         return;


### PR DESCRIPTION
Our organization found a bug where if a website uses a CSS selector `id=browser` on any HTML elements, a global `browser` variable gets created. This interferes with the current implementation of the `detectBrowser` function when running on Chrome because the conditional logic sees `typeof browser !== "undefined"` as a truthy expression. This causes `vuex-webextensions` to incorrectly define the browser object as Firefox, and prevents the content and background scripts from syncing as expected.

This was first noted on the site [resellerclub.com](https://www.resellerclub.com/) on Chrome. When on that site, you can open devtools and type `browser` into the console. You will see an `HTMLCollection` object defined under that global variable name. 

This PR updates the conditional logic to check for the `InstallTrigger` object ([docs](https://developer.mozilla.org/en-US/docs/Web/API/InstallTrigger) ) in order to verify whether a browser is Firefox. The idea for this implementation came from this [stack overflow post](https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser). 