### PR TITLE
fix: update rollup format to commonJS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default [
     input: './src/index.js',
     output: {
       file: './dist/index.js',
-      format: 'iife',
+      format: 'cjs',
       name: 'index',
       sourcemap: true
     },


### PR DESCRIPTION
Based on the rollup [docs](https://rollupjs.org/guide/en/#outputformat), the `iife` format is better suited for use in the `<script>` tag. Since extensions may bootstrap from the background script, it seems that the commonJS format may be a better approach. 

This builds the `index.js` file in such a way that it creates a default export, whereas the `iife` format did not. 

This is in relation to [issue 54](https://github.com/MitsuhaKitsune/vuex-webextensions/issues/54) that I opened today. 

@MitsuhaKitsune would it help if I went ahead and incremented the package numbers for `npm` in this PR? 